### PR TITLE
Подгон хука под текущий опенрести

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM openresty/openresty:bionic
 
 COPY ./lualib /usr/local/openresty/lualib/v8/
-
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-http && /usr/local/openresty/luajit/bin/luarocks install base64
 RUN rm /etc/nginx/conf.d/*.conf
 COPY ./storage.conf /etc/nginx/conf.d

--- a/nginx/lualib/commitFilter.lua
+++ b/nginx/lualib/commitFilter.lua
@@ -1,7 +1,7 @@
 local _M = {}
 
 function _M.apply(pattern)
-
+   
     ngx.req.read_body()
 
     local req = ngx.var.request_body
@@ -25,9 +25,14 @@ function _M.apply(pattern)
 
     -- проверка на пустой комментарий
     if message == nil then
-        ngx.status = ngx.HTTP_BAD_REQUEST
-        ngx.say("Empty comment is not allowed")
-        ngx.exit(ngx.HTTP_BAD_REQUEST)
+        ngx.status = ngx.OK
+        local b64 = require("base64")
+        answer = b64.encode("{{3ccb2518-9616-4445-aaa7-20048fead174,\"При помещении в хранилище комментарий должен быть заполнен\",{9f06d311-1431-4a54-bd6f-fa93c4d4c471,{9f06d311-1431-4a54-bd6f-fa93c4d4c471,\"\",{00000000-0000-0000-0000-000000000000},\"\"}},\"\",\"0000000000000000000\",00000000-0000-0000-0000-000000000000},17,{\"file:///var/opt/1C/repo/\",0},\"\"}")
+
+        ngx.var.commitfiltered = "true"
+        ngx.header["Content-Type"] = "application/xml"
+        ngx.say(string.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?><crs:call_exception xmlns:crs=\"http://v8.1c.ru/8.2/crs\" clsid=\"3ccb2518-9616-4445-aaa7-20048fead174\">77u/%s</crs:call_exception>", answer))
+        ngx.exit(ngx.status)
     end
 
     -- вот здесь можно написать свои проверки
@@ -36,6 +41,7 @@ function _M.apply(pattern)
         if matches ~= nil then
             return
         else
+            ngx.var.commitfiltered = "true"
             ngx.status = ngx.HTTP_BAD_REQUEST
             ngx.say("Comment is not matched our team standards")
             ngx.exit(ngx.HTTP_BAD_REQUEST)

--- a/nginx/lualib/webhook.lua
+++ b/nginx/lualib/webhook.lua
@@ -9,7 +9,7 @@
 
 local _M = {}
 
-function sendhook(premature)
+function sendhook(premature, hookurl, hookbody)
     if premature then
         return
     end
@@ -42,15 +42,13 @@ function _M.call(url, body)
         return
     end
 
-    hookurl =  url
-    hookbody = body
     local req = ngx.var.request_body
     if req == nil then
         return
     end
 
     if string.find(req, "DevDepot_commitObjects") then
-        ngx.timer.at(0, sendhook)
+        ngx.timer.at(0, sendhook, url, body)
     end
 end
 

--- a/nginx/storage.conf
+++ b/nginx/storage.conf
@@ -7,6 +7,9 @@ server {
 
     location / {
         
+        # используется для отмены хука в случае когда фильтр отработал
+        set $commitfiltered "false";
+
         # значения этих параметров ОБЯЗАТЕЛЬНО должны быть одинаковыми
         # https://github.com/openresty/lua-nginx-module#lua_need_request_body
         client_body_buffer_size 2048m;


### PR DESCRIPTION
Вебхук работает на текущем опенрести.
Сообщение о пустом комментарии воспринимается конфигуратором как родное.
![image](https://user-images.githubusercontent.com/15638529/158985153-fd44f4bb-3ae6-426b-b0f6-13d1e898ebbc.png)

 